### PR TITLE
Fix incrementalFetchingLimit = 0 => it means disabled.

### DIFF
--- a/src/Configuration/NodeDefinition/TableNodesDecorator.php
+++ b/src/Configuration/NodeDefinition/TableNodesDecorator.php
@@ -11,8 +11,20 @@ class TableNodesDecorator
 {
     public const DEFAULT_MAX_TRIES = 5;
 
+    public function normalize(array $v): array
+    {
+        // Backward compatibility: some older configurations may use "zero" in the meaning of "disabled"".
+        if (($v['incrementalFetchingLimit'] ?? null) === 0) {
+            $v['incrementalFetchingLimit'] = null;
+        }
+
+        return $v;
+    }
+
     public function validate(array $v): array
     {
+        $v  = $this->normalize($v);
+
         if (empty($v['query']) && empty($v['table'])) {
             throw new InvalidConfigurationException('Table or query must be configured.');
         }
@@ -140,7 +152,7 @@ class TableNodesDecorator
                 ->cannotBeEmpty()
             ->end()
             ->integerNode('incrementalFetchingLimit')
-                ->min(0)
+                ->min(0) // zero is taken as disabled
             ->end();
         // @formatter:on
     }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -8,8 +8,11 @@ use Keboola\DbExtractorConfig\Config;
 use Keboola\DbExtractorConfig\Configuration\ActionConfigRowDefinition;
 use Keboola\DbExtractorConfig\Configuration\ConfigDefinition;
 use Keboola\DbExtractorConfig\Configuration\ConfigRowDefinition;
+use Keboola\DbExtractorConfig\Configuration\ValueObject\ExportConfig;
+use Keboola\DbExtractorConfig\Exception\PropertyNotSetException;
 use Keboola\DbExtractorConfig\Exception\UserException as ConfigUserException;
 use Keboola\DbExtractorConfig\Test\AbstractConfigTest;
+use PHPUnit\Framework\Assert;
 
 class ConfigTest extends AbstractConfigTest
 {
@@ -561,5 +564,64 @@ class ConfigTest extends AbstractConfigTest
             'The path "root.parameters.primaryKey.1" cannot contain an empty value, but got "".'
         );
         new Config($configurationArray, new ConfigRowDefinition());
+    }
+
+    public function testIncrementalFetchingLimit(): void
+    {
+        $configurationArray = [
+            'parameters' => [
+                'data_dir' => '/code/tests/Keboola/DbExtractor/../../data',
+                'extractor_class' => 'MySQL',
+                'table' => [
+                    'tableName' => 'table',
+                    'schema' => 'schema',
+                ],
+                'outputTable' => 'output-table',
+                'retries' => 12,
+                'columns' => [],
+                'primaryKey' => [],
+                'incremental' => true,
+                'incrementalFetchingColumn' => 'col123',
+                'incrementalFetchingLimit' => 456, // <<<<<<<<<<
+            ],
+        ];
+
+        // Normalized
+        $expected = $configurationArray;
+        $expected['parameters']['query'] = null;
+        $expected['parameters']['enabled'] = true;
+
+        $config = new Config($configurationArray, new ConfigRowDefinition());
+        $this->assertEquals($expected, $config->getData());
+    }
+
+    public function testIncrementalFetchingLimitZero(): void
+    {
+        $configurationArray = [
+            'parameters' => [
+                'data_dir' => '/code/tests/Keboola/DbExtractor/../../data',
+                'extractor_class' => 'MySQL',
+                'table' => [
+                    'tableName' => 'table',
+                    'schema' => 'schema',
+                ],
+                'outputTable' => 'output-table',
+                'retries' => 12,
+                'columns' => [],
+                'primaryKey' => [],
+                'incremental' => true,
+                'incrementalFetchingColumn' => 'col123',
+                'incrementalFetchingLimit' => 0, // <<<<<<<<<<
+            ],
+        ];
+
+        // Normalized
+        $expected = $configurationArray;
+        $expected['parameters']['incrementalFetchingLimit'] = null;
+        $expected['parameters']['query'] = null;
+        $expected['parameters']['enabled'] = true;
+
+        $config = new Config($configurationArray, new ConfigRowDefinition());
+        $this->assertEquals($expected, $config->getData());
     }
 }

--- a/tests/ValueObject/ExportConfigTest.php
+++ b/tests/ValueObject/ExportConfigTest.php
@@ -209,6 +209,10 @@ class ExportConfigTest extends TestCase
         Assert::assertSame(true, $config->isIncrementalFetching());
         Assert::assertSame('col123', $config->getIncrementalFetchingConfig()->getColumn());
         Assert::assertSame('col123', $config->getIncrementalFetchingColumn());
+
+        Assert::assertFalse($config->hasIncrementalFetchingLimit());
+        Assert::assertFalse($config->getIncrementalFetchingConfig()->hasLimit());
+
         try {
             $config->getIncrementalFetchingConfig()->getLimit();
             Assert::fail('Exception is expected.');
@@ -238,6 +242,9 @@ class ExportConfigTest extends TestCase
             'incrementalFetchingColumn' => 'col123',
             'incrementalFetchingLimit' => 456,
         ]);
+
+        Assert::assertTrue($config->hasIncrementalFetchingLimit());
+        Assert::assertTrue($config->getIncrementalFetchingConfig()->hasLimit());
 
         // Incremental fetching
         Assert::assertSame(true, $config->isIncrementalFetching());


### PR DESCRIPTION
Changelog:
- Fixed BC,  if `incrementalFetchingLimit = 0`, it is converted to `null`.