### PR TITLE
Fix ExportConfig::configId -> integer node

### DIFF
--- a/src/Configuration/ValueObject/ExportConfig.php
+++ b/src/Configuration/ValueObject/ExportConfig.php
@@ -9,7 +9,7 @@ use Keboola\DbExtractorConfig\Exception\PropertyNotSetException;
 class ExportConfig implements ValueObject
 {
     /** Id of config row or tables config item */
-    private ?string $configId;
+    private ?int $configId;
 
     /** Name of config row or tables config item */
     private ?string $configName;
@@ -51,7 +51,7 @@ class ExportConfig implements ValueObject
     }
 
     public function __construct(
-        ?string $configId,
+        ?int $configId,
         ?string $configName,
         ?string $query,
         ?InputTable $table,
@@ -79,7 +79,7 @@ class ExportConfig implements ValueObject
         return $this->configId !== null;
     }
 
-    public function getConfigId(): string
+    public function getConfigId(): int
     {
         if ($this->configId === null) {
             throw new PropertyNotSetException('Config id is not set.');

--- a/tests/ValueObject/ExportConfigTest.php
+++ b/tests/ValueObject/ExportConfigTest.php
@@ -289,7 +289,7 @@ class ExportConfigTest extends TestCase
     public function testConfigIdAndName(): void
     {
         $config = ExportConfig::fromArray([
-            'id' => 'my config id',
+            'id' => 123,
             'name' => 'my config name',
             'table' => [
                 'tableName' => 'table',
@@ -304,7 +304,7 @@ class ExportConfigTest extends TestCase
 
         Assert::assertTrue($config->hasConfigId());
         Assert::assertTrue($config->hasConfigName());
-        Assert::assertSame('my config id', $config->getConfigId());
+        Assert::assertSame(123, $config->getConfigId());
         Assert::assertSame('my config name', $config->getConfigName());
     }
 }


### PR DESCRIPTION
Changes:
- Fix ExportConfig::configId type `string` -> `integer`
- `id` is integer, not scalar node: https://github.com/keboola/db-extractor-config/blob/3c7a90fa01c4079423f2eb1aa5721794f9cffd43/src/Configuration/NodeDefinition/TableNodesDecorator.php#L87-L89