### PR TITLE
Add GetTablesListFilterDefinition

### DIFF
--- a/src/Configuration/GetTablesListFilterDefinition.php
+++ b/src/Configuration/GetTablesListFilterDefinition.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractorConfig\Configuration;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
+class GetTablesListFilterDefinition extends ActionConfigRowDefinition
+{
+    protected function getParametersDefinition(): ArrayNodeDefinition
+    {
+        $parametersNode = parent::getParametersDefinition();
+
+        // @formatter:off
+        $parametersNode
+            ->ignoreExtraKeys(true)
+            ->children()
+                ->arrayNode('tableListFilter')
+                    ->children()
+                        ->booleanNode('listColumns')->defaultTrue()->end()
+                        ->arrayNode('tablesToList')
+                            ->prototype('array')
+                                ->children()
+                                    ->scalarNode('tableName')->end()
+                                    ->scalarNode('schema')->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+        // @formatter:on
+
+        return $parametersNode;
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -8,11 +8,9 @@ use Keboola\DbExtractorConfig\Config;
 use Keboola\DbExtractorConfig\Configuration\ActionConfigRowDefinition;
 use Keboola\DbExtractorConfig\Configuration\ConfigDefinition;
 use Keboola\DbExtractorConfig\Configuration\ConfigRowDefinition;
-use Keboola\DbExtractorConfig\Configuration\ValueObject\ExportConfig;
-use Keboola\DbExtractorConfig\Exception\PropertyNotSetException;
+use Keboola\DbExtractorConfig\Configuration\GetTablesListFilterDefinition;
 use Keboola\DbExtractorConfig\Exception\UserException as ConfigUserException;
 use Keboola\DbExtractorConfig\Test\AbstractConfigTest;
-use PHPUnit\Framework\Assert;
 
 class ConfigTest extends AbstractConfigTest
 {
@@ -623,5 +621,46 @@ class ConfigTest extends AbstractConfigTest
 
         $config = new Config($configurationArray, new ConfigRowDefinition());
         $this->assertEquals($expected, $config->getData());
+    }
+
+    public function testGetTablesSimple(): void
+    {
+        $configurationArray = [
+            'action' => 'getTables',
+            'parameters' => [
+                'data_dir' => '/code/tests/Keboola/DbExtractor/../../data',
+                'extractor_class' => 'MySQL',
+            ],
+        ];
+
+        new Config($configurationArray, new GetTablesListFilterDefinition());
+        $this->expectNotToPerformAssertions(); // no error expected
+    }
+
+    public function testGetTablesListFilter(): void
+    {
+        $configurationArray = [
+            'action' => 'getTables',
+            'parameters' => [
+                'data_dir' => '/code/tests/Keboola/DbExtractor/../../data',
+                'extractor_class' => 'MySQL',
+                'tableListFilter' => [
+                    'listColumns' => true,
+                    'tablesToList' => [
+                        [
+                            'tableName' => 'table1',
+                            'schema' => 'default',
+                        ],
+                        [
+                            'tableName' => 'table2',
+                            'schema' => 'default',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        new Config($configurationArray, new GetTablesListFilterDefinition());
+        $this->expectNotToPerformAssertions(); // no error expected
     }
 }


### PR DESCRIPTION
Changes:
- Added `GetTablesListFilterDefinition` - it can be used with extractors which uses 2-step `getTables` (first only tables without columns, and then only one table with columns), ... so far this code has been duplicated in individual extractors, even if they use the same UI interface.