### PR TITLE
Fix missing difference between: incremental loading and inc. fetching

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,4 @@ parameters:
     checkMissingIterableValueType: false
     ignoreErrors:
         - '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\).#'
-        - '#Cannot call method arrayNode\(\) on Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface\|null.#'
-        - '#Cannot call method scalarNode\(\) on Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface\|null.#'
+        - '#Cannot call method .*\(\) on Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface\|null.#'

--- a/src/Configuration/NodeDefinition/TableNodesDecorator.php
+++ b/src/Configuration/NodeDefinition/TableNodesDecorator.php
@@ -47,23 +47,10 @@ class TableNodesDecorator
             );
         }
 
-        if ($v['incremental'] === true && empty($v['incrementalFetchingColumn'])) {
-            throw new InvalidConfigurationException(
-                'The "incrementalFetchingColumn" must be configured, if incremental fetching is enabled.'
-            );
-        }
-
-        if ($v['incremental'] === false && !empty($v['incrementalFetchingColumn'])) {
-            throw new InvalidConfigurationException(
-                'The "incrementalFetchingColumn" is configured, ' .
-                'but incremental fetching is not enabled.'
-            );
-        }
-
-        if ($v['incremental'] === false && !empty($v['incrementalFetchingLimit'])) {
+        if (!empty($v['incrementalFetchingLimit']) && empty($v['incrementalFetchingColumn'])) {
             throw new InvalidConfigurationException(
                 'The "incrementalFetchingLimit" is configured, ' .
-                'but incremental fetching is not enabled.'
+                'but "incrementalFetchingColumn" is missing.'
             );
         }
 
@@ -78,6 +65,7 @@ class TableNodesDecorator
         $this->addTableNode($builder);
         $this->addColumnsNode($builder);
         $this->addOutputTableNode($builder);
+        $this->addIncrementalLoading($builder);
         $this->addIncrementalFetchingNodes($builder);
         $this->addEnabledNode($builder);
         $this->addPrimaryKeyNode($builder);
@@ -141,13 +129,22 @@ class TableNodesDecorator
         // @formatter:on
     }
 
+    protected function addIncrementalLoading(NodeBuilder $builder): void
+    {
+        // NOTE: "incremental" key enables incremental loading to storage table,
+        // it is not directly related to incrementalFetching, it's a different feature!
+
+        // @formatter:off
+        $builder
+            ->booleanNode('incremental')
+                ->defaultValue(false);
+        // @formatter:on
+    }
+
     protected function addIncrementalFetchingNodes(NodeBuilder $builder): void
     {
         // @formatter:off
         $builder
-            ->booleanNode('incremental')
-                ->defaultValue(false)
-            ->end()
             ->scalarNode('incrementalFetchingColumn')
                 ->cannotBeEmpty()
             ->end()

--- a/src/Configuration/ValueObject/ExportConfig.php
+++ b/src/Configuration/ValueObject/ExportConfig.php
@@ -20,6 +20,14 @@ class ExportConfig implements ValueObject
     /** Table that will be exported (if query is not set) */
     private ?InputTable $table;
 
+    /**
+     * If enabled, new rows are added and existing (same PK value) are updated.
+     * If disabled, full load is performed and the storage table is overwritten.
+     * It's a different feature from incrementalFetching!
+     * @var bool
+     */
+    private bool $incrementalLoading;
+
     /** Configuration of incremental fetching */
     private ?IncrementalFetchingConfig $incrementalFetchingConfig;
 
@@ -42,6 +50,7 @@ class ExportConfig implements ValueObject
             $data['name'] ?? null,
             $data['query'],
             empty($data['query']) ? InputTable::fromArray($data) : null,
+            $data['incremental'] ?? false,
             empty($data['query']) ? IncrementalFetchingConfig::fromArray($data) : null,
             $data['columns'],
             $data['outputTable'],
@@ -55,6 +64,7 @@ class ExportConfig implements ValueObject
         ?string $configName,
         ?string $query,
         ?InputTable $table,
+        bool $incrementalLoading,
         ?IncrementalFetchingConfig $incrementalFetchingConfig,
         array $columns,
         string $outputTable,
@@ -67,6 +77,7 @@ class ExportConfig implements ValueObject
         $outputTable = trim($outputTable);
         $this->query = $query;
         $this->table = $table;
+        $this->incrementalLoading = $incrementalLoading;
         $this->incrementalFetchingConfig = $incrementalFetchingConfig;
         $this->columns = $columns;
         $this->outputTable = $outputTable;
@@ -114,6 +125,11 @@ class ExportConfig implements ValueObject
         }
 
         return $this->table;
+    }
+
+    public function isIncrementalLoading(): bool
+    {
+        return $this->incrementalLoading;
     }
 
     public function isIncrementalFetching(): bool

--- a/src/Configuration/ValueObject/IncrementalFetchingConfig.php
+++ b/src/Configuration/ValueObject/IncrementalFetchingConfig.php
@@ -16,7 +16,7 @@ class IncrementalFetchingConfig implements ValueObject
     public static function fromArray(array $data): ?self
     {
         // Enabled ?
-        if (empty($data['incremental'])) {
+        if (empty($data['incrementalFetchingColumn'])) {
             return null;
         }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -11,6 +11,7 @@ use Keboola\DbExtractorConfig\Configuration\ConfigRowDefinition;
 use Keboola\DbExtractorConfig\Configuration\GetTablesListFilterDefinition;
 use Keboola\DbExtractorConfig\Exception\UserException as ConfigUserException;
 use Keboola\DbExtractorConfig\Test\AbstractConfigTest;
+use PHPUnit\Framework\Assert;
 
 class ConfigTest extends AbstractConfigTest
 {
@@ -452,7 +453,7 @@ class ConfigTest extends AbstractConfigTest
         new Config($configurationArray, new ConfigRowDefinition());
     }
 
-    public function testMissingIncrementalFetchingColumn(): void
+    public function testIncrementalLoadingWithNoIncrementalFetchingColumn(): void
     {
         $configurationArray = [
             'parameters' => [
@@ -467,14 +468,27 @@ class ConfigTest extends AbstractConfigTest
             ],
         ];
 
-        $this->expectException(ConfigUserException::class);
-        $this->expectExceptionMessage(
-            'The "incrementalFetchingColumn" must be configured, if incremental fetching is enabled.'
-        );
-        new Config($configurationArray, new ConfigRowDefinition());
+        $config = new Config($configurationArray, new ConfigRowDefinition());
+        Assert::assertSame([
+            'parameters' => [
+                'data_dir' => '/code/tests/Keboola/DbExtractor/../../data',
+                'extractor_class' => 'MySQL',
+                'outputTable' => 'in.c-main.auto-increment-timestamp',
+                'table' => [
+                    'tableName' => 'name',
+                    'schema' => 'schema',
+                ],
+                'incremental' => true,
+                'query' => null,
+                'columns' => [],
+                'enabled' => true,
+                'primaryKey' => [],
+                'retries' => 5,
+            ],
+        ], $config->getData());
     }
 
-    public function testIncrementalFetchingColumnSetButIncrementalDisabled(): void
+    public function testIncrementalFetchingColumnAndNoIncrementalLoading(): void
     {
         $configurationArray = [
             'parameters' => [
@@ -490,14 +504,28 @@ class ConfigTest extends AbstractConfigTest
             ],
         ];
 
-        $this->expectException(ConfigUserException::class);
-        $this->expectExceptionMessage(
-            'The "incrementalFetchingColumn" is configured, but incremental fetching is not enabled.'
-        );
-        new Config($configurationArray, new ConfigRowDefinition());
+        $config = new Config($configurationArray, new ConfigRowDefinition());
+        Assert::assertSame([
+            'parameters' => [
+                'data_dir' => '/code/tests/Keboola/DbExtractor/../../data',
+                'extractor_class' => 'MySQL',
+                'outputTable' => 'in.c-main.auto-increment-timestamp',
+                'table' => [
+                    'tableName' => 'name',
+                    'schema' => 'schema',
+                ],
+                'incremental' => false,
+                'incrementalFetchingColumn' => 'name',
+                'query' => null,
+                'columns' => [],
+                'enabled' => true,
+                'primaryKey' => [],
+                'retries' => 5,
+            ],
+        ], $config->getData());
     }
 
-    public function testIncrementalFetchingLimitSetButIncrementalDisabled(): void
+    public function testIncrementalFetchingLimitButNoColumn(): void
     {
         $configurationArray = [
             'parameters' => [
@@ -515,7 +543,7 @@ class ConfigTest extends AbstractConfigTest
 
         $this->expectException(ConfigUserException::class);
         $this->expectExceptionMessage(
-            'The "incrementalFetchingLimit" is configured, but incremental fetching is not enabled.'
+            'The "incrementalFetchingLimit" is configured, but "incrementalFetchingColumn" is missing.'
         );
         new Config($configurationArray, new ConfigRowDefinition());
     }

--- a/tests/ValueObject/IncrementalFetchingConfigTest.php
+++ b/tests/ValueObject/IncrementalFetchingConfigTest.php
@@ -25,7 +25,6 @@ class IncrementalFetchingConfigTest extends TestCase
     {
         /** @var IncrementalFetchingConfig $config */
         $config = IncrementalFetchingConfig::fromArray([
-            'incremental' => true,
             'incrementalFetchingColumn' => 'col123',
         ]);
         Assert::assertSame('col123', $config->getColumn());
@@ -41,7 +40,6 @@ class IncrementalFetchingConfigTest extends TestCase
     {
         /** @var IncrementalFetchingConfig $config */
         $config = IncrementalFetchingConfig::fromArray([
-            'incremental' => true,
             'incrementalFetchingColumn' => 'col123',
             'incrementalFetchingLimit' => 456,
         ]);


### PR DESCRIPTION
Changes:
- Solving: https://keboola.atlassian.net/browse/COM-261
- Fixed  bug, `incremental: true` in the old code meant `incrementalFetching` is on, ... but `incrementalFetching` should be on if `incrementalFetchingColumn` is set ... 
- `incremental: true` turns on [Incremental loading](https://developers.keboola.com/extend/generic-extractor/incremental/) not incremental fetching.
- These features are usually used together, but are independent.
- For example, `incremental loading` can be used with a custom query, but `incremental fetching` not.