### PR TITLE
Fix DbNode and SshNode extensibility

### DIFF
--- a/src/Configuration/NodeDefinition/DbNode.php
+++ b/src/Configuration/NodeDefinition/DbNode.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\DbExtractorConfig\Configuration\NodeDefinition;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeParentInterface;
 
@@ -24,30 +25,59 @@ class DbNode extends ArrayNodeDefinition
         parent::__construct(self::NODE_NAME, $parent);
         $this->sshNode = $sshNode ?? new SshNode();
         $this->sslNode = $sslNode ?? new SslNode();
-        $this->init();
+        $this->init($this->children());
     }
 
-    protected function init(): void
+    protected function init(NodeBuilder $builder): void
     {
-        // @formatter:off
-        $this
-            ->children()
-                ->scalarNode('driver')->end()
-                ->scalarNode('host')->end()
-                ->scalarNode('port')->end()
-                ->scalarNode('database')
-                    ->cannotBeEmpty()
-                ->end()
-                ->scalarNode('user')
-                    ->isRequired()
-                ->end()
-                ->scalarNode('#password')
-                    ->isRequired()
-                ->end()
-                ->append($this->sshNode)
-                ->append($this->sslNode)
-            ->end()
-        ;
-        // @formatter:on
+        $this->addDriverNode($builder);
+        $this->addHostNode($builder);
+        $this->addPortNode($builder);
+        $this->addDatabaseNode($builder);
+        $this->addUserNode($builder);
+        $this->addPasswordNode($builder);
+        $this->addSshNode($builder);
+        $this->addSslNode($builder);
+    }
+
+    protected function addDriverNode(NodeBuilder $builder): void
+    {
+        // For backward compatibility only
+        $builder->scalarNode('driver');
+    }
+
+    protected function addHostNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('host');
+    }
+
+    protected function addPortNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('port');
+    }
+
+    protected function addDatabaseNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('database')->cannotBeEmpty();
+    }
+
+    protected function addUserNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('user')->isRequired();
+    }
+
+    protected function addPasswordNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('#password')->isRequired();
+    }
+
+    protected function addSshNode(NodeBuilder $builder): void
+    {
+        $builder->append($this->sshNode);
+    }
+
+    protected function addSslNode(NodeBuilder $builder): void
+    {
+        $builder->append($this->sslNode);
     }
 }

--- a/src/Configuration/NodeDefinition/SshNode.php
+++ b/src/Configuration/NodeDefinition/SshNode.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\DbExtractorConfig\Configuration\NodeDefinition;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\NodeParentInterface;
 
 class SshNode extends ArrayNodeDefinition
@@ -14,32 +15,69 @@ class SshNode extends ArrayNodeDefinition
     public function __construct(?NodeParentInterface $parent = null)
     {
         parent::__construct(self::NODE_NAME, $parent);
-        $this->init();
+        $this->init($this->children());
     }
 
-    protected function init(): void
+    protected function init(NodeBuilder $builder): void
+    {
+        $this->addEnabledNode($builder);
+        $this->addKeysNode($builder);
+        $this->addSshHostNode($builder);
+        $this->addSshPortNode($builder);
+        $this->addRemoteHostNode($builder);
+        $this->addRemotePortNode($builder);
+        $this->addLocalPortNode($builder);
+        $this->addUserNode($builder);
+        $this->addCompressionNode($builder);
+    }
+
+    protected function addEnabledNode(NodeBuilder $builder): void
+    {
+        $builder->booleanNode('enabled');
+    }
+
+    protected function addKeysNode(NodeBuilder $builder): void
     {
         // @formatter:off
-        $this
+        $builder->arrayNode('keys')
             ->children()
-                ->booleanNode('enabled')->end()
-                ->arrayNode('keys')
-                    ->children()
-                        ->scalarNode('#private')->end()
-                        ->scalarNode('public')->end()
-                    ->end()
-                ->end()
-                ->scalarNode('sshHost')->end()
-                ->scalarNode('sshPort')->end()
-                ->scalarNode('remoteHost')->end()
-                ->scalarNode('remotePort')->end()
-                ->scalarNode('localPort')->end()
-                ->scalarNode('user')->end()
-                ->booleanNode('compression')
-                    ->defaultValue(false)
-                ->end()
-            ->end()
-        ;
+                ->scalarNode('#private')->end()
+                ->scalarNode('public')->end();
         // @formatter:on
+    }
+
+    protected function addSshHostNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('sshHost');
+    }
+
+    protected function addSshPortNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('sshPort');
+    }
+
+    protected function addRemoteHostNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('remoteHost');
+    }
+
+    protected function addRemotePortNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('remotePort');
+    }
+
+    protected function addLocalPortNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('localPort');
+    }
+
+    protected function addUserNode(NodeBuilder $builder): void
+    {
+        $builder->scalarNode('user');
+    }
+
+    protected function addCompressionNode(NodeBuilder $builder): void
+    {
+        $builder->booleanNode('compression')->defaultValue(false);
     }
 }

--- a/src/Configuration/NodeDefinition/SslNode.php
+++ b/src/Configuration/NodeDefinition/SslNode.php
@@ -10,7 +10,6 @@ use Symfony\Component\Config\Definition\Builder\NodeParentInterface;
 
 class SslNode extends ArrayNodeDefinition
 {
-
     private const NODE_NAME = 'ssl';
 
     public function __construct(?NodeParentInterface $parent = null)


### PR DESCRIPTION
Changes:
- Fix `DbNode` and `SshNode` extensibility, .... for example `db.port` can be modified (eg. some default value) without the need to rewrite the whole method `DbNode::init`.