### PR TITLE
Fix incremental fetching limit

### DIFF
--- a/src/Configuration/NodeDefinition/TableNodesDecorator.php
+++ b/src/Configuration/NodeDefinition/TableNodesDecorator.php
@@ -146,10 +146,14 @@ class TableNodesDecorator implements DecoratorInterface
         // @formatter:off
         $builder
             ->scalarNode('incrementalFetchingColumn')
-                ->cannotBeEmpty()
+                ->defaultNull()
             ->end()
             ->integerNode('incrementalFetchingLimit')
-                ->min(0) // zero is taken as disabled
+                // In old configs can be incrementalFetchingLimit = null, preserve backward compatibility
+                // Null value cannot be enabled on integer node in different way
+                ->treatNullLike(0)
+                // Zero is taken as disabled, see "self::normalize" method
+                ->min(0)
             ->end();
         // @formatter:on
     }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -111,6 +111,7 @@ class ConfigTest extends AbstractConfigTest
                         'enabled' => true,
                         'columns' => [],
                         'retries' => 5,
+                        'incrementalFetchingColumn' => null,
                     ],
                     [
                         'id' => 2,
@@ -124,6 +125,7 @@ class ConfigTest extends AbstractConfigTest
                         'enabled' => true,
                         'columns' => [],
                         'retries' => 20,
+                        'incrementalFetchingColumn' => null,
                     ],
                     [
                         'id' => 3,
@@ -144,6 +146,7 @@ class ConfigTest extends AbstractConfigTest
                         ],
                         'retries' => 30,
                         'query' => null,
+                        'incrementalFetchingColumn' => null,
                     ],
                 ],
             ],
@@ -373,6 +376,7 @@ class ConfigTest extends AbstractConfigTest
                 'query' => 'SELECT 1 FROM test',
                 'outputTable' => 'testOutput',
                 'columns' => [],
+                'incrementalFetchingColumn' => null,
                 'incremental' => false,
                 'enabled' => true,
                 'primaryKey' => [],
@@ -495,6 +499,7 @@ class ConfigTest extends AbstractConfigTest
                 'incremental' => true,
                 'query' => null,
                 'columns' => [],
+                'incrementalFetchingColumn' => null,
                 'enabled' => true,
                 'primaryKey' => [],
                 'retries' => 5,
@@ -704,5 +709,51 @@ class ConfigTest extends AbstractConfigTest
 
         new Config($configurationArray, new GetTablesListFilterDefinition());
         $this->expectNotToPerformAssertions(); // no error expected
+    }
+
+    public function testIncrementalFetchingLimitNull(): void
+    {
+        $configurationArray = [
+            'parameters' => [
+                'data_dir' => '/code/tests/Keboola/DbExtractor/../../data',
+                'extractor_class' => 'MySQL',
+                'table' => [
+                    'tableName' => 'table',
+                    'schema' => 'schema',
+                ],
+                'outputTable' => 'output-table',
+                'retries' => 12,
+                'columns' => [],
+                'primaryKey' => [],
+                'incremental' => false,
+                'incrementalFetchingLimit' => null, // <<<<<<<<<<
+            ],
+        ];
+
+        $config = new Config($configurationArray, new ConfigRowDefinition());
+        Assert::assertSame(null, $config->getData()['incrementalFetchingLimit']);
+    }
+
+    public function testIncrementalFetchingColumnNull(): void
+    {
+        $configurationArray = [
+            'parameters' => [
+                'data_dir' => '/code/tests/Keboola/DbExtractor/../../data',
+                'extractor_class' => 'MySQL',
+                'table' => [
+                    'tableName' => 'table',
+                    'schema' => 'schema',
+                ],
+                'outputTable' => 'output-table',
+                'retries' => 12,
+                'columns' => [],
+                'primaryKey' => [],
+                'incremental' => false,
+                'incrementalFetchingColumn' => null, // <<<<<<<<<<
+            ],
+        ];
+
+        $config = new Config($configurationArray, new ConfigRowDefinition());
+        Assert::assertSame(null, $config->getData()['incrementalFetchingColumn']);
     }
 }

--- a/tests/ValueObject/ExportConfigTest.php
+++ b/tests/ValueObject/ExportConfigTest.php
@@ -268,6 +268,38 @@ class ExportConfigTest extends TestCase
         }
     }
 
+    public function testIncrementalFetchingColumnNull(): void
+    {
+        $config = ExportConfig::fromArray([
+            'table' => [
+                'tableName' => 'table',
+                'schema' => 'schema',
+            ],
+            'outputTable' => 'output-table',
+            'retries' => 12,
+            'columns' => [],
+            'primaryKey' => [],
+            'incrementalFetchingColumn' => null, // <<<<<<<<<<
+        ]);
+        Assert::assertFalse($config->isIncrementalFetching());
+    }
+
+    public function testIncrementalFetchingLimitNull(): void
+    {
+        $config = ExportConfig::fromArray([
+            'table' => [
+                'tableName' => 'table',
+                'schema' => 'schema',
+            ],
+            'outputTable' => 'output-table',
+            'retries' => 12,
+            'columns' => [],
+            'primaryKey' => [],
+            'incrementalFetchingLimit' => null, // <<<<<<<<<<
+        ]);
+        Assert::assertFalse($config->isIncrementalFetching());
+    }
+
     public function testIncrementalLoading(): void
     {
         $config = ExportConfig::fromArray([


### PR DESCRIPTION
Slack: https://keboola.slack.com/archives/CQ1ASK06M/p1592895218010800

In old config can be `incrementalFetchingLimit: null`, so backward compatibility must be fixed.

**Config:**
![image](https://user-images.githubusercontent.com/19371734/85419105-f3891280-b571-11ea-9cdd-b171c3210832.png)

**Error:**
![image](https://user-images.githubusercontent.com/19371734/85419145-fedc3e00-b571-11ea-80b0-90bbf2797f86.png)
